### PR TITLE
sub-skip react to opt changes

### DIFF
--- a/sub-skip.lua
+++ b/sub-skip.lua
@@ -6,9 +6,17 @@ local cfg = {
 	lead_in = 0,
 	lead_out = 1
 }
+local script_name = mp.get_script_name()
 
 require 'mp.options'
-read_options(cfg)
+read_options(cfg, script_name, function(changes)
+	if (changes.default_state) then
+		mp.commandv('script-message-to', script_name, 'sub-skip-toggle')
+	end
+	if (changes.seek_mode_default) then
+		mp.commandv('script-message-to', script_name, 'sub-skip-switch-mode')
+	end
+end)
 
 local active = cfg.default_state
 local seek_skip = cfg.seek_mode_default


### PR DESCRIPTION
Hi,

i am using conditional auto profiles to apply script opts which will be applied after the first script initialization (and therefore initial option values).

PR is adding the options callback handler for default_state and seek_mode in order to handle changes coming from auto profiles.