### PR TITLE
feat: don't skip/pause if no subtitle track is selected

### DIFF
--- a/sub-pause.lua
+++ b/sub-pause.lua
@@ -59,6 +59,10 @@ function handle_tick(_, time_pos)
 end
 
 function handle_sub_change(_, sub_end)
+	--if no subtitle track loaded then we don't need to try to pause
+	if mp.get_property_number('sid', -1) == -1 then
+		return
+	end
 	mp.unobserve_property(handle_tick)
 	if sub_end ~= nil then
 		if pause_at_start then pause() end

--- a/sub-skip.lua
+++ b/sub-skip.lua
@@ -149,6 +149,10 @@ function end_skip()
 end
 
 function handle_sub_change(_, sub_end)
+	--if no subtitle track loaded then we don't need to start skipping
+	if mp.get_property_number('sid', -1) == -1 then
+		return
+	end
 	if not sub_end and not skipping then
 		local time_pos = mp.get_property_number("time-pos")
 		local next_delay = calc_next_delay()


### PR DESCRIPTION
Currently if there is no subtitle selected and the scripts are set to `default_state = true', they will attempt to run as if there are subtitles loaded i.e. the whole video will be skipped. This PR adds a check to prevent this behaviour.